### PR TITLE
Réécriture du README et ajout d'un README en français

### DIFF
--- a/README-FR.md
+++ b/README-FR.md
@@ -19,7 +19,7 @@ Le bot est en réécriture. Je vous conseille d'attendre la fin de la réécritu
 ![](http://35.237.77.248/ressources/tuto.png)
 
 # Liens
-* [Ste web](http://draftbot.tk)
+* [Site web](http://draftbot.tk)
 * [Serveur Discord](https://discord.gg/p2HQVmT)
 * [Tableau Trello](https://trello.com/b/mJidA4EI/draftbot)
 * [Compte Twitter](https://twitter.com/DraftBot_?s=09)

--- a/README-FR.md
+++ b/README-FR.md
@@ -12,7 +12,7 @@ DraftBot est une bot Discord développé en Node.js par [@BastLast](https://gith
 
 <br>
 
-# Status du développement
+# Statut du développement
 Le bot est en réécriture. Je vous conseille d'attendre la fin de la réécriture avant d'y contribuer.
 
 # Images

--- a/README-FR.md
+++ b/README-FR.md
@@ -1,0 +1,29 @@
+<center>
+<img src="http://35.237.77.248/ressources/couronne.png" style="border-radius: 50%; width: 300px">
+
+# **DraftBot - Une aventure Discord**
+DraftBot est une bot Discord développé en Node.js par [@BastLast](https://github.com/BastLast) basé sur un jeu d'aventure sur du texte.
+
+[![](https://img.shields.io/discord/429765017332613120.svg)](https://discord.gg/AP3Wmzb)
+[![](https://img.shields.io/website-up-down-green-red/http/35.237.77.248.svg?label=draftbot.tk)](http://draftbot.tk/)
+[![](https://img.shields.io/github/stars/BastLast/DraftBot-A-Discord-Adventure.svg?label=Stars&style=social)](https://github.com/BastLast/DraftBot-A-Discord-Adventure)
+
+</center>
+
+<br>
+
+# Status du développement
+Le bot est en réécriture. Je vous conseille d'attendre la fin de la réécriture avant d'y contribuer.
+
+# Images
+![](http://35.237.77.248/ressources/tuto.png)
+
+# Liens
+* [Ste web](http://draftbot.tk)
+* [Serveur Discord](https://discord.gg/p2HQVmT)
+* [Tableau Trello](https://trello.com/b/mJidA4EI/draftbot)
+* [Compte Twitter](https://twitter.com/DraftBot_?s=09)
+* [Formulaire de suggestions](https://docs.google.com/forms/d/e/1FAIpQLSdCjD4qm0e6jIapvT3vKRZkeFnhHA8oLIthoBg3kcWeqIWvDg/viewform)
+
+# Credits
+https://github.com/Formula-9/AnotherDimensionBot

--- a/README.md
+++ b/README.md
@@ -1,24 +1,29 @@
-**DraftBot - A Discord Adventure**
-=======================
+<center>
+<img src="http://35.237.77.248/ressources/couronne.png" style="border-radius: 50%; width: 300px">
 
-A work-in-progress Discord bot using Node.js to provide a
-text-based adventure game!
+# **DraftBot - A Discord Adventure**
+DraftBot is a bot developed in Node.js by [@BastLast](https://github.com/BastLast) based on an adventure game on text.
 
-_______________________
-Current Status
------------------------
+[![](https://img.shields.io/discord/429765017332613120.svg)](https://discord.gg/AP3Wmzb)
+[![](https://img.shields.io/website-up-down-green-red/http/35.237.77.248.svg?label=draftbot.tk)](http://draftbot.tk/)
+[![](https://img.shields.io/github/stars/BastLast/DraftBot-A-Discord-Adventure.svg?label=Stars&style=social)](https://github.com/BastLast/DraftBot-A-Discord-Adventure)
 
-The bot is beeing rewriting for now please stand by
+</center>
 
-_______________________
-Links
------------------------
+<br>
 
-http://draftbot.tk
-https://discord.gg/p2HQVmT
+# Development status
+The bot is rewriting. I advise you to wait until the end of the rewrite before contributing.
 
-_______________________
-Thanks
------------------------
+# Screenshots
+![](http://35.237.77.248/ressources/tuto.png)
 
+# Links
+* [Web site *(in french)*](http://draftbot.tk)
+* [Discord server *(in french)*](https://discord.gg/p2HQVmT)
+* [Trello board *(in french)*](https://trello.com/b/mJidA4EI/draftbot)
+* [Twitter account *(in french)*](https://twitter.com/DraftBot_?s=09)
+* [Suggestion form *(in french)*](https://docs.google.com/forms/d/e/1FAIpQLSdCjD4qm0e6jIapvT3vKRZkeFnhHA8oLIthoBg3kcWeqIWvDg/viewform)
+
+# Credits
 https://github.com/Formula-9/AnotherDimensionBot


### PR DESCRIPTION
Pour avoir plus d'informations sur le projet, j'ai modifié le `README.md` :
* Ajout du logo
* Modification de la description
* Ajout de badges :
  * Serveur Discord
  * Site web
  * Stars du le dépôt GitHub
* Modification du statut du développement
* Ajout de liens :
  * Tableau Trello
  * Compte Twitter
  * Formulaire de suggestions

Comme le bot est créé par un français, j'ai aussi traduit le `README.md` en français : `README-FR.md` que vous pouvez trouver à la racine du dépôt.

Les fichiers Makdown ne sont pas très lisibles en brut, si vous voulez voir le résultat : visionnez les fichiers dans mon dépôt : [README](https://github.com/YaFou/DraftBot-A-Discord-Adventure/blob/master/README.md) et le [README-FR](https://github.com/YaFou/DraftBot-A-Discord-Adventure/blob/master/README-FR.md).