### PR TITLE
Changement xp event 34

### DIFF
--- a/ressources/text/events/34.json
+++ b/ressources/text/events/34.json
@@ -63,7 +63,7 @@
                 "lostTime": 85,
                 "health": 0,
                 "effect": ":clock2:",
-                "experience": 25,
+                "experience": 125,
                 "money": 350,
                 "item": false
             },


### PR DESCRIPTION
Changement de l'xp obtenue dans la 3e issue du choix 2 où le gain d'argent n'avait pas été pris en compte.