### PR TITLE
Fix du texte de la commande invite #139

### DIFF
--- a/ressources/text/commands/help.json
+++ b/ressources/text/commands/help.json
@@ -91,7 +91,7 @@
 				"invite": {
 					"emote": ":inbox_tray:",
 					"usage": "invite",
-					"description": "Cette commande vous permet d'obtenir un lien permettant de faire venir le bot sur votre serveur ou de rejoindre le serveur d'aide !"
+					"description": "Cette commande vous permet d'obtenir un lien permettant de rejoindre le serveur d'aide !"
 				},
 				"badge": {
 					"emote": ":military_medal:",


### PR DESCRIPTION
Le texte de la commande invite n'était pas clair. J'ai donc corrigé ce problème.